### PR TITLE
ユーザー認証の不具合を修正

### DIFF
--- a/RewindPM.Web/Components/Pages/Projects/Detail.razor
+++ b/RewindPM.Web/Components/Pages/Projects/Detail.razor
@@ -369,6 +369,6 @@ else
     private string GetCurrentUserId()
     {
         // TODO: 認証サービスから実際のユーザーIDを取得する
-        throw new NotImplementedException("ユーザー認証が未実装です");
+        return "admin";
     }
 }


### PR DESCRIPTION
未実装のユーザー認証機能がエラーを返すためにタスクの変更ができなくなっていた。
仮のIDを返すようにしてエラーが出ないようにした